### PR TITLE
Update grand_master_cas.js

### DIFF
--- a/lib/grand_master_cas.js
+++ b/lib/grand_master_cas.js
@@ -1,5 +1,6 @@
 var http = require('http');
 var https = require('https');
+var xml = require('xmldoc').XmlDocument;
 
 var GrandMasterCas = function(){
   this.configure = this.configure.bind(this);
@@ -67,7 +68,7 @@ GrandMasterCas.prototype.handleTicket = function( req, res, next ){
   var ticket = req.query.ticket;
   var sessionName = this.sessionName;
   var service = this.service;
-  var path = this.casPath + '/validate?service=' + service + '&ticket=' + ticket;
+  var path = this.casPath + '/serviceValidate?service=' + service + '&ticket=' + ticket;
 
   var that = this;
 
@@ -82,17 +83,19 @@ GrandMasterCas.prototype.handleTicket = function( req, res, next ){
       buf += chunk.toString('utf8');
     });
     response.on('end', function(){
-      var results = buf.split('\n');
-      if (results[0] === 'yes') {
-        req.session[sessionName] = results[1];
+      var results = new xml(buf);
+      var auth = results.childNamed('cas:authenticationSuccess');
+      if (auth) {
+        var cas = {};
+        auth.eachChild(function(child){
+          cas[child.name] = child.val;
+        });
+        req.session['casValidation'] = cas;
         next();
       }
-      else if (results[0] === 'no') {
+      else  {
         // thisBinding is lost here
         res.redirect(that.redirectUrl);
-      }
-      else {
-        console.log('invalid response from CAS');
       }
     });
     response.on('error', function(err){


### PR DESCRIPTION
would also need to include 'xmldoc' as dependency. I tried to work around this but unfortunately the default config is to expire tickets as soon as they are used once. Otherwise I would have just reused the ticket to do /serviceValidate. Luckily this path still fits with your intentions. If you accept this then I could keep my dependencies orderly and it would help others I am sure. Otherwise I have already forked this to suit my needs. Have a good day.

PS: It might need a little sanitation. Not sure that cas['cas:user'] would be legal.
